### PR TITLE
chore: release v2.1.0 — Reliability + Zero-Friction Install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to engram are documented here. Format based on
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-04-21 — "Reliability + Zero-Friction Install"
+
+First release in the v2.1 / v2.2 / v3.0 elevation trilogy. Design spec
+at `docs/superpowers/specs/2026-04-20-engram-elevation-trilogy-design.md`.
+
+Headline: `engram setup` is the new one-command first-run flow. Users
+go from `npm install -g engramx` to a working Sentinel hook + indexed
+graph in under 30 seconds. `engram doctor` reports component health
+with remediation hints. `engram update` ships future hotfixes to every
+install without surprise — passive notify, zero telemetry, one-command
+upgrade. Plus fixes for issue #11 (AST/LSP path bug in flattened
+bundles) and issue #14's Bash-ops half (auto-reindex on `rm`/`mv`/
+`git rm` via an opt-in PostToolUse gate).
+
+Contributor credit this release: [@gabiudrescu](https://github.com/gabiudrescu)
+for PR #13 (reindex CLI + `install-hook --auto-reindex`), PR #12
+(watcher prune on delete/rename), and the original v2.0.2 security
+disclosure. [@ttessarolo](https://github.com/ttessarolo) for precise
+forensics + suggested fix on issue #11.
+
 ### Added — v2.1 "Reliability + Zero-Friction Install" track
 
 - **`engram update`** — one-command self-upgrade.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "engramx",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "engramx",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engramx",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "The context spine for AI coding agents. 8 providers + pluggable context sources, 3-layer memory cache, web dashboard, multi-IDE support (Claude Code, Cursor, Continue, Zed, Aider, Windsurf, Neovim, Emacs). 88.1% measured session-level token savings. Local SQLite, zero native deps, zero cloud.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release PR — v2.1.0

Bumps engramx from 2.0.2 to 2.1.0. No code changes beyond the version bump, `package-lock.json` sync, and CHANGELOG header rehoming.

Everything else has already landed on main via:
- PR #12 (@gabiudrescu): watcher prune on delete/rename
- PR #13 (@gabiudrescu): engram reindex CLI + install-hook --auto-reindex
- PR #15: v2.1 seamless install track (update / doctor / setup) + #11 fix + #14 Bash-ops parser

## Post-merge checklist (irreversible actions — your hands)

```bash
# 1. Tag the release
git checkout main
git pull origin main
git tag -a v2.1.0 -m "v2.1.0 Reliability + Zero-Friction Install"
git push --tags

# 2. npm publish (requires 2FA)
npm publish

# 3. GitHub Release with generated notes
gh release create v2.1.0 --generate-notes \
  --title "v2.1.0 — Reliability + Zero-Friction Install"

# 4. Smoke-test the published version on a fresh machine
#    (verify the global-install flattened-bundle #11 fix)
npm install -g engramx@2.1.0
cd /tmp/new-project && engram setup -y && engram doctor
```

## What ships

See [CHANGELOG.md §2.1.0](https://github.com/NickCirv/engram/blob/release/v2.1.0/CHANGELOG.md#210--2026-04-21--reliability--zero-friction-install) for the full notes. Highlights:

- **Seamless install** — `engram setup` drops first-value from 4 commands to 1
- **Self-update** — `engram update` with passive notify, zero telemetry
- **Diagnostics** — `engram doctor` wraps component probes + remediation hints
- **Fix #11** — AST grammar detection works on global installs (was broken in v2.0.2 for every `npm install -g` user)
- **Fix #14 half** — Bash auto-reindex parser (opt-in via ENGRAM_AUTO_REINDEX=1)
- **Contributor credits** — @gabiudrescu (PR #12, #13), @ttessarolo (#11 forensics)

## Not in this release

- **PR #6 (OOM)** — contributor's PR still dirty + red. Will land in v2.1.1 or v2.2 after rebase.
- **v2.2 Serena provider** — scoped in trilogy spec, starts after v2.1.0 publishes and stabilizes.
- **v3.0 Landmines** — placeholder in trilogy spec, full spec written after v2.2 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)