### PR TITLE
fix: pin encoding on readdirSync for Node 25 type compatibility

### DIFF
--- a/bench/real-world.ts
+++ b/bench/real-world.ts
@@ -90,7 +90,7 @@ function collectSourceFiles(root: string, cap: number): string[] {
     if (out.length >= cap) return;
     let entries: ReturnType<typeof readdirSync>;
     try {
-      entries = readdirSync(dir, { withFileTypes: true });
+      entries = readdirSync(dir, { withFileTypes: true, encoding: "utf-8" });
     } catch {
       return;
     }

--- a/src/miners/ast-miner.ts
+++ b/src/miners/ast-miner.ts
@@ -612,7 +612,7 @@ export function extractDirectory(
 
     let entries: Dirent[];
     try {
-      entries = readdirSync(dir, { withFileTypes: true });
+      entries = readdirSync(dir, { withFileTypes: true, encoding: "utf-8" });
     } catch {
       return;
     }


### PR DESCRIPTION
## Summary

Add `encoding: "utf-8"` to `readdirSync` calls in `ast-miner.ts` and `real-world.ts` to fix TypeScript errors in Node 25:

```
error TS2322: Type "Dirent<string>[]" is not assignable to type "Dirent<NonSharedBuffer>[]".
error TS2339: Property "startsWith" does not exist on type "NonSharedBuffer".
```

## Changes

- `src/miners/ast-miner.ts:615` — add `encoding: "utf-8"` to readdirSync
- `bench/real-world.ts:93` — same fix

Same pattern as `skills-miner.ts:226-229`.

## Tests

All 17 ast-miner tests pass.